### PR TITLE
Remove Gophercon 2015 and CascadiaFest 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This repo tracks upcoming developer conferences. To add a conference to this lis
 
 | Conference Name                                                  | Location        | Start Date             | End Date    | Hash Tag    |
 | :--------------------------------------------------------------: |:-------------:  | :---------------------:| :----------:| :---------: |
-| [Gophercon 2015](http://www.gophercon.com/)  | Denver          | 07/07/15 | 07/10/15 | [#gophercon](https://twitter.com/search?f=realtime&q=%23gophercon)
-| [CascadiaFest 2015](http://2015.cascadiajs.com/)  | Blaine, WA          | 07/08/15 | 07/10/15 | [#cjsfest15](https://twitter.com/search?f=realtime&q=%23cjs15)
 [PyGotham](https://pygotham.org/2015/)                         | New York, NY    | 08/15/15 | 08/16/15 | [#pygotham](https://twitter.com/search?f=realtime&q=%23pygotham)
 | [Texas Linux Fest](http://www.texaslinuxfest.org/)                     | Austin | 08/21/15 | 08/22/15 | [#txlf](https://twitter.com/search?f=realtime&q=%23txlf)
 [dotGo](http://www.dotgo.eu/)  | Paris          | 09/09/15 | 09/11/15 | [#dotGo](https://twitter.com/search?f=realtime&q=%23dotGo)


### PR DESCRIPTION
Both of these conferences have* ended.

\* CascadiaFest is probably still going on at the time of writing this, but it will likely be over by the time this request is seen / processed.